### PR TITLE
Simplify Figma MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,15 +2,13 @@
   "mcpServers": {
     "framelink-figma-mcp": {
       "type": "stdio",
-      "command": "npx",
+      "command": "figma-developer-mcp",
       "args": [
         "-y",
         "figma-developer-mcp",
-        "--figma-api-key=${FIGMA_API_KEY}"
-      ],
-      "env": {
-        "FIGMA_API_KEY": "${FIGMA_API_KEY:-KEY_NOT_SET}"
-      }
+        "--figma-api-key=${FIGMA_API_KEY}",
+        "--stdio"
+      ]
     }
   }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Update command to use direct `figma-developer-mcp` instead of `npx` wrapper
- Remove redundant environment variable configuration that was duplicating the API key
- Add `--stdio` flag for proper stdio communication protocol

## Test plan
- [ ] Verify Figma MCP server can be started with the new configuration
- [ ] Test that Figma API integration works correctly with the simplified setup
- [ ] Confirm environment variables are still properly resolved

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)